### PR TITLE
Fix image paths to use public/images directory

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -144,7 +144,7 @@
                 const extensions = ['png', 'jpg', 'jpeg', 'webp'];
                 
                 for (const ext of extensions) {
-                    const imagePath = `./uploads/${slug}.${ext}`;
+                    const imagePath = `./images/${slug}.${ext}`;
                     if (await this.checkImageExists(imagePath)) {
                         return `<img src="${imagePath}" alt="${hero.superhero_name}" class="max-w-full max-h-full object-contain rounded-lg shadow-lg">`;
                     }

--- a/scripts/audit-images.js
+++ b/scripts/audit-images.js
@@ -13,7 +13,6 @@ const path = require('path');
 // Configuration
 const HEROES_JSON_PATH = path.join(__dirname, '../public/heroes.json');
 const IMAGE_DIRECTORIES = [
-    path.join(__dirname, '../uploads'),
     path.join(__dirname, '../public/images')
 ];
 const SUPPORTED_EXTENSIONS = ['png', 'jpg', 'jpeg', 'webp', 'gif', 'svg'];


### PR DESCRIPTION
- Update getHeroImage function in index.html to look in ./images/ instead of ./uploads/
- Update image audit script to scan only public/images directory
- Remove uploads directory from audit scanning as images are now consolidated

🤖 Generated with [Claude Code](https://claude.ai/code)